### PR TITLE
@RxLogSubscriber crashes with NullPointerException

### DIFF
--- a/frodo-runtime/src/main/java/com/fernandocejas/frodo/aspect/LogSubscriber.java
+++ b/frodo-runtime/src/main/java/com/fernandocejas/frodo/aspect/LogSubscriber.java
@@ -78,9 +78,9 @@ public class LogSubscriber {
   public void beforeOnNextExecution(JoinPoint joinPoint) {
     countAndMeasureTime();
     final FrodoJoinPoint frodoJoinPoint = new FrodoJoinPoint(joinPoint);
-    final Object value = frodoJoinPoint.getMethodParamValuesList().get(0);
-    messageManager.printSubscriberOnNext(joinPoint.getTarget().getClass().getSimpleName(),
-        value.toString(),
+    final Object value = frodoJoinPoint.getMethodParamValuesList().isEmpty() ? null
+        : frodoJoinPoint.getMethodParamValuesList().get(0);
+    messageManager.printSubscriberOnNext(joinPoint.getTarget().getClass().getSimpleName(), value,
         Thread.currentThread().getName());
   }
 

--- a/frodo-runtime/src/main/java/com/fernandocejas/frodo/internal/MessageBuilder.java
+++ b/frodo-runtime/src/main/java/com/fernandocejas/frodo/internal/MessageBuilder.java
@@ -44,6 +44,7 @@ class MessageBuilder {
   private static final String RECEIVED_ELEMENTS_LABEL = LOG_START + "Received" + VALUE_SEPARATOR;
   private static final String LABEL_ELEMENT_SINGULAR = " element";
   private static final String LABEL_ELEMENT_PLURAL = " elements";
+  private static final String LABEL_MESSAGE_NULL_OBSERVABLES = "You received a null observable";
 
   MessageBuilder() {}
 
@@ -156,14 +157,14 @@ class MessageBuilder {
     return message.toString();
   }
 
-  String buildSubscriberOnNextMessage(String subscriberName, String value, String threadName) {
+  String buildSubscriberOnNextMessage(String subscriberName, Object value, String threadName) {
     final StringBuilder message = buildSubscriberSB();
     message.append(SEPARATOR);
     message.append(subscriberName);
     message.append(VALUE_SEPARATOR);
     message.append(LABEL_SUBSCRIBER_ON_NEXT);
     message.append(VALUE_SEPARATOR);
-    message.append(value);
+    message.append(value != null ? value.toString() : LABEL_MESSAGE_NULL_OBSERVABLES);
     message.append(SEPARATOR);
     message.append(LABEL_SUBSCRIBER_OBSERVE_ON);
     message.append(threadName);

--- a/frodo-runtime/src/main/java/com/fernandocejas/frodo/internal/MessageManager.java
+++ b/frodo-runtime/src/main/java/com/fernandocejas/frodo/internal/MessageManager.java
@@ -68,7 +68,7 @@ public class MessageManager {
     this.printMessage(subscriberName, message);
   }
 
-  public void printSubscriberOnNext(String subscriberName, String value, String threadName) {
+  public void printSubscriberOnNext(String subscriberName, Object value, String threadName) {
     final String message =
         messageBuilder.buildSubscriberOnNextMessage(subscriberName, value, threadName);
     this.printMessage(subscriberName, message);

--- a/frodo-runtime/src/main/java/com/fernandocejas/frodo/joinpoint/FrodoJoinPoint.java
+++ b/frodo-runtime/src/main/java/com/fernandocejas/frodo/joinpoint/FrodoJoinPoint.java
@@ -45,10 +45,15 @@ public class FrodoJoinPoint {
     this.classCanonicalName = this.methodSignature.getDeclaringType().getCanonicalName();
     this.classSimpleName = this.methodSignature.getDeclaringType().getSimpleName();
     this.methodName = this.methodSignature.getName();
-    this.methodParamTypesList = Arrays.asList(this.methodSignature.getParameterTypes());
-    this.methodParamNamesList = Arrays.asList(this.methodSignature.getParameterNames());
-    this.methodParamValuesList = Arrays.asList(this.joinPoint.getArgs());
     this.executionThreadName = Thread.currentThread().getName();
+    final Class[] parameterTypes = this.methodSignature.getParameterTypes();
+    final String[] parameterNames = this.methodSignature.getParameterNames();
+    final Object[] args = this.joinPoint.getArgs();
+    this.methodParamTypesList = parameterTypes != null ?
+        Arrays.asList(parameterTypes) : Collections.<Class>emptyList();
+    this.methodParamNamesList = parameterNames != null ?
+        Arrays.asList(parameterNames) : Collections.<String>emptyList();
+    this.methodParamValuesList = args != null ? Arrays.asList(args) : Collections.emptyList();
     this.joinPointUniqueName = this.generateJoinPointUniqueName();
   }
 

--- a/frodo-runtime/src/test/java/com/fernandocejas/frodo/aspect/LogSubscriberTest.java
+++ b/frodo-runtime/src/test/java/com/fernandocejas/frodo/aspect/LogSubscriberTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -87,6 +88,20 @@ public class LogSubscriberTest {
     verify(stopWatch).start();
     verify(messageManager).printSubscriberOnNext(eq(subscriber.getClass().getSimpleName()),
         eq("value"), anyString());
+  }
+
+  @Test public void printOnNextMessageBeforeSubscriberOnNextExecutionWithEmptyValues() {
+    final TestJoinPoint joinPointTest =
+        new TestJoinPoint.Builder(subscriber.getClass()).withParamTypes(String.class)
+            .withParamNames("param")
+            .withParamValues()
+            .build();
+    logSubscriber.beforeOnNextExecution(joinPointTest);
+
+    verify(counter).increment();
+    verify(stopWatch).start();
+    verify(messageManager).printSubscriberOnNext(eq(subscriber.getClass().getSimpleName()),
+        anyObject(), anyString());
   }
 
   @Test


### PR DESCRIPTION
Fixed #14. The @RxLogSubscriber crashes with NullPointerException when the param values are empty eg. ```Observable.just(null)```